### PR TITLE
Ensure gateway cleanup on loop exit

### DIFF
--- a/src/interactor/use_cases/run_gateway_use_case.py
+++ b/src/interactor/use_cases/run_gateway_use_case.py
@@ -97,9 +97,12 @@ class RunGatewayUseCase:
             print(f"\nERROR: Gateway start failed: {str(e)}")
             return False
         finally:
-            if self.running:
-                self.gateway_initializer_service.cleanup_zmq()
-                self.running = False
+            # Always clean up resources even if the event loop already
+            # stopped and self.running is False. This ensures ZeroMQ
+            # sockets are closed when the gateway exits normally or
+            # due to an exception.
+            self.gateway_initializer_service.cleanup_zmq()
+            self.running = False
 
     def execute_in_thread(self) -> bool:
         """Execute the gateway in threaded mode.

--- a/src/interactor/use_cases/test/test_run_gateway_use_case.py
+++ b/src/interactor/use_cases/test/test_run_gateway_use_case.py
@@ -98,6 +98,23 @@ def test_success_threaded(capsys):
     # Ensure cleanup was called after run
     assert gw.cleaned is True
 
+def test_cleanup_called_when_loop_exits_normally():
+    logger = DummyLogger()
+    gw = DummyGatewayInit(init_ok=True, connect_ok=True)
+    uc = RunGatewayUseCase(
+        logger,
+        port_checker_service=DummyPortChecker({1: True}),
+        gateway_initializer_service=gw,
+        session_repository=DummySession(True),
+    )
+    def fake_loop(*_):
+        # Simulate a normal shutdown by clearing the running flag inside the loop
+        uc.running = False
+    uc._run_event_loop = fake_loop
+    result = uc.execute(is_threaded_mode=True)
+    assert result is True
+    assert gw.cleaned is True
+
 def test_stop_sets_running_false():
     logger = DummyLogger()
     uc = RunGatewayUseCase(logger,


### PR DESCRIPTION
## Summary
- clean up ZMQ sockets regardless of running flag
- add a test ensuring cleanup when loop ends normally

## Testing
- `pytest src/interactor/use_cases/test/test_run_gateway_use_case.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424a13f9948330afef4b4989f9b755